### PR TITLE
[#10] Remove WorkflowExecution.OnActionComplete

### DIFF
--- a/cloudkeeper-core/cloudkeeper-basic/src/main/java/com/svbio/cloudkeeper/simple/WorkflowExecutions.java
+++ b/cloudkeeper-core/cloudkeeper-basic/src/main/java/com/svbio/cloudkeeper/simple/WorkflowExecutions.java
@@ -1,14 +1,9 @@
 package com.svbio.cloudkeeper.simple;
 
-import akka.dispatch.Futures;
 import com.svbio.cloudkeeper.dsl.DSLOutPort;
 import com.svbio.cloudkeeper.model.api.WorkflowExecution;
-import scala.concurrent.Await;
-import scala.concurrent.Promise;
-import scala.concurrent.duration.Duration;
-import scala.util.Failure;
-import scala.util.Success;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -17,58 +12,11 @@ public final class WorkflowExecutions {
         throw new AssertionError(String.format("No %s instances for you!", getClass().getName()));
     }
 
-    private static class WhenComplete<T> implements WorkflowExecution.OnActionComplete<T> {
-        private final Promise<T> promise = Futures.promise();
-
-        @Override
-        public void complete(Throwable throwable, T value) {
-            promise.complete(throwable != null
-                ? new Failure<T>(throwable)
-                : new Success<>(value)
-            );
-        }
-
-        private T await(long timeout, TimeUnit unit) throws AwaitException, TimeoutException, InterruptedException {
-            try {
-                return Await.result(promise.future(), Duration.create(timeout, unit));
-            } catch (TimeoutException | InterruptedException exception) {
-                throw exception;
-            } catch (Exception exception) {
-                throw new AwaitException(exception);
-            }
-        }
-    }
-
-    public static long getExecutionId(WorkflowExecution workflowExecution, long timeout, TimeUnit unit)
-        throws AwaitException, TimeoutException, InterruptedException {
-
-        WhenComplete<Long> whenComplete = new WhenComplete<>();
-        workflowExecution.whenHasExecutionId(whenComplete);
-        return whenComplete.await(timeout, unit);
-    }
-
-    public static Object getOutputValue(WorkflowExecution workflowExecution, String outPortName, long timeout,
-        TimeUnit unit) throws AwaitException, TimeoutException, InterruptedException {
-
-        WhenComplete<Object> whenComplete = new WhenComplete<>();
-        workflowExecution.whenHasOutput(outPortName, whenComplete);
-        return whenComplete.await(timeout, unit);
-    }
-
     public static <T> T getOutputValue(WorkflowExecution workflowExecution, DSLOutPort<T> outPort, long timeout,
-        TimeUnit unit) throws AwaitException, TimeoutException, InterruptedException {
-
+            TimeUnit unit) throws ExecutionException, TimeoutException, InterruptedException {
         // TODO: It should be verified that the DSL port fits to this workflow execution.
         @SuppressWarnings("unchecked")
-        T outputValue = (T) getOutputValue(workflowExecution, outPort.getSimpleName().toString(), timeout, unit);
+        T outputValue = (T) workflowExecution.getOutput(outPort.getSimpleName().toString()).get(timeout, unit);
         return outputValue;
-    }
-
-    public static void awaitFinish(WorkflowExecution workflowExecution, long timeout, TimeUnit unit)
-        throws AwaitException, TimeoutException, InterruptedException {
-
-        WhenComplete<Void> whenComplete = new WhenComplete<>();
-        workflowExecution.whenExecutionFinished(whenComplete);
-        whenComplete.await(timeout, unit);
     }
 }

--- a/cloudkeeper-core/cloudkeeper-basic/src/test/java/com/svbio/cloudkeeper/simple/SingleVMCloudKeeperTest.java
+++ b/cloudkeeper-core/cloudkeeper-basic/src/test/java/com/svbio/cloudkeeper/simple/SingleVMCloudKeeperTest.java
@@ -75,8 +75,8 @@ public class SingleVMCloudKeeperTest {
         int result = WorkflowExecutions.getOutputValue(
             workflowExecution, binarySumModule.sum(), WAIT_SECONDS, TimeUnit.SECONDS);
         Assert.assertEquals(result, 10);
-        WorkflowExecutions.awaitFinish(workflowExecution, WAIT_SECONDS, TimeUnit.SECONDS);
 
+        workflowExecution.toCompletableFuture().get(WAIT_SECONDS, TimeUnit.SECONDS);
         simpleCloudKeeper.shutdown();
     }
 
@@ -95,7 +95,7 @@ public class SingleVMCloudKeeperTest {
             workflowExecution, fibonacciModule.result(), WAIT_SECONDS, TimeUnit.SECONDS);
         Assert.assertEquals(result, 5);
 
-        WorkflowExecutions.awaitFinish(workflowExecution, WAIT_SECONDS, TimeUnit.SECONDS);
+        workflowExecution.toCompletableFuture().get(WAIT_SECONDS, TimeUnit.SECONDS);
     }
 
     @Test
@@ -108,11 +108,10 @@ public class SingleVMCloudKeeperTest {
             .setBundleIdentifiers(Arrays.asList(SimpleRepository.BUNDLE_ID, FibonacciRepository.BUNDLE_ID))
             .setInputs(Collections.singletonMap(SimpleName.identifier("n"), (Object) 5))
             .start();
-        int result = (Integer) WorkflowExecutions.getOutputValue(
-            workflowExecution, "result", WAIT_SECONDS, TimeUnit.SECONDS);
+        int result = (Integer) workflowExecution.getOutput("result").get(WAIT_SECONDS, TimeUnit.SECONDS);
         Assert.assertEquals(result, 5);
 
-        WorkflowExecutions.awaitFinish(workflowExecution, WAIT_SECONDS, TimeUnit.SECONDS);
+        workflowExecution.toCompletableFuture().get(WAIT_SECONDS, TimeUnit.SECONDS);
     }
 
     @Test
@@ -127,15 +126,12 @@ public class SingleVMCloudKeeperTest {
             .start();
 
         for (int k = 0; k <= n; ++k) {
-            Object object
-                = WorkflowExecutions.getOutputValue(workflowExecution, "coef_" + k, WAIT_SECONDS, TimeUnit.SECONDS);
-
             Assert.assertEquals(
-                (int) object,
+                (int) workflowExecution.getOutput("coef_" + k).get(WAIT_SECONDS, TimeUnit.SECONDS),
                 binomial(n, k)
             );
         }
-        WorkflowExecutions.awaitFinish(workflowExecution, WAIT_SECONDS, TimeUnit.SECONDS);
+        workflowExecution.toCompletableFuture().get(WAIT_SECONDS, TimeUnit.SECONDS);
     }
 
     private static int binomial(int n, int k) {

--- a/cloudkeeper-core/cloudkeeper-dsl/src/main/java/com/svbio/cloudkeeper/dsl/DSLInPort.java
+++ b/cloudkeeper-core/cloudkeeper-dsl/src/main/java/com/svbio/cloudkeeper/dsl/DSLInPort.java
@@ -1,10 +1,17 @@
 package com.svbio.cloudkeeper.dsl;
 
 import com.svbio.cloudkeeper.model.bare.element.module.BareInPort;
+import com.svbio.cloudkeeper.model.immutable.element.SimpleName;
+
+import javax.annotation.Nonnull;
 
 /**
  * Tagging interface for DSL in-ports.
  *
  * @param <T> type of the port
  */
-public interface DSLInPort<T> extends BareInPort { }
+public interface DSLInPort<T> extends BareInPort {
+    @Nonnull
+    @Override
+    SimpleName getSimpleName();
+}

--- a/cloudkeeper-core/cloudkeeper-dsl/src/main/java/com/svbio/cloudkeeper/dsl/DSLOutPort.java
+++ b/cloudkeeper-core/cloudkeeper-dsl/src/main/java/com/svbio/cloudkeeper/dsl/DSLOutPort.java
@@ -1,10 +1,17 @@
 package com.svbio.cloudkeeper.dsl;
 
 import com.svbio.cloudkeeper.model.bare.element.module.BareOutPort;
+import com.svbio.cloudkeeper.model.immutable.element.SimpleName;
+
+import javax.annotation.Nonnull;
 
 /**
  * Tagging interface for DSL out-ports.
  *
  * @param <T> type of the port
  */
-public interface DSLOutPort<T> extends BareOutPort { }
+public interface DSLOutPort<T> extends BareOutPort {
+    @Nonnull
+    @Override
+    SimpleName getSimpleName();
+}

--- a/cloudkeeper-core/cloudkeeper-interpreter/src/main/java/com/svbio/cloudkeeper/interpreter/CloudKeeperEnvironmentBuilder.java
+++ b/cloudkeeper-core/cloudkeeper-interpreter/src/main/java/com/svbio/cloudkeeper/interpreter/CloudKeeperEnvironmentBuilder.java
@@ -121,13 +121,11 @@ public final class CloudKeeperEnvironmentBuilder {
     }
 
     /**
-     * Sets whether intermediate results should be results should be retrieved and made available through
-     * {@link WorkflowExecution#whenHasOutput(String, WorkflowExecution.OnActionComplete)}.
+     * Sets whether results should be retrieved and made available through {@link WorkflowExecution#getOutput(String)}.
      *
-     * <p>If this option is set to {@code false}, any callback registered with
-     * {@link WorkflowExecution#whenHasOutput(String, WorkflowExecution.OnActionComplete)} will always receive a
-     * {@link com.svbio.cloudkeeper.model.api.WorkflowExecutionException} once the out-port value is available in the
-     * staging area.
+     * <p>If this option is set to {@code false}, the futures returned by {@link WorkflowExecution#getOutput(String)}
+     * will always be completed exceptionally with a {@link com.svbio.cloudkeeper.model.api.WorkflowExecutionException}
+     * once the out-port value is available in the staging area.
      *
      * <p>By default, this option is set to {@code true}.
      *

--- a/cloudkeeper-samples/cloudkeeper-sample-maven-runner/src/main/java/com/svbio/cloudkeeper/samples/maven/ModuleRunner.java
+++ b/cloudkeeper-samples/cloudkeeper-sample-maven-runner/src/main/java/com/svbio/cloudkeeper/samples/maven/ModuleRunner.java
@@ -17,7 +17,6 @@ import com.svbio.cloudkeeper.model.util.ImmutableList;
 import com.svbio.cloudkeeper.simple.DSLExecutableProvider;
 import com.svbio.cloudkeeper.simple.SimpleInstanceProvider;
 import com.svbio.cloudkeeper.simple.SingleVMCloudKeeper;
-import com.svbio.cloudkeeper.simple.WorkflowExecutions;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
@@ -132,8 +131,9 @@ public final class ModuleRunner {
             .setInputs(Collections.singletonMap(configuration.inPort, input))
             .setBundleIdentifiers(Collections.singletonList(configuration.dependency))
             .start();
-        String output = (String) WorkflowExecutions.getOutputValue(
-            workflowExecution, configuration.outPort.toString(), configuration.timeoutSeconds, TimeUnit.SECONDS);
+        String output = (String) workflowExecution
+            .getOutput(configuration.outPort.toString())
+            .get(configuration.timeoutSeconds, TimeUnit.SECONDS);
 
         cloudKeeper.shutdown().awaitTermination();
         Await.result(actorSystem.terminate(), Duration.Inf());

--- a/cloudkeeper-samples/cloudkeeper-sample-single-vm/src/main/java/com/svbio/cloudkeeper/samples/FileManipulationFuture.java
+++ b/cloudkeeper-samples/cloudkeeper-sample-single-vm/src/main/java/com/svbio/cloudkeeper/samples/FileManipulationFuture.java
@@ -13,7 +13,6 @@ import com.svbio.cloudkeeper.model.CloudKeeperSerialization;
 import com.svbio.cloudkeeper.model.api.CloudKeeperEnvironment;
 import com.svbio.cloudkeeper.model.api.WorkflowExecution;
 import com.svbio.cloudkeeper.model.util.ByteSequences;
-import com.svbio.cloudkeeper.simple.AwaitException;
 import com.svbio.cloudkeeper.simple.WorkflowExecutions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,14 +87,10 @@ public final class FileManipulationFuture implements Future<FileManipulationResu
     public FileManipulationResult get(long timeout, TimeUnit unit)
         throws InterruptedException, ExecutionException, TimeoutException {
 
-        try {
-            ByteSequence byteSequence = WorkflowExecutions.getOutputValue(execution, module.outText(), timeout, unit);
-            int numberOfLines = WorkflowExecutions.getOutputValue(execution, module.outNumLines(), timeout, unit);
-            long sizeOfFile = WorkflowExecutions.getOutputValue(execution, module.outTextSize(), timeout, unit);
-            return new FileManipulationResult(byteSequence, numberOfLines, sizeOfFile);
-        } catch (AwaitException exception) {
-            throw new ExecutionException(exception);
-        }
+        ByteSequence byteSequence = WorkflowExecutions.getOutputValue(execution, module.outText(), timeout, unit);
+        int numberOfLines = WorkflowExecutions.getOutputValue(execution, module.outNumLines(), timeout, unit);
+        long sizeOfFile = WorkflowExecutions.getOutputValue(execution, module.outTextSize(), timeout, unit);
+        return new FileManipulationResult(byteSequence, numberOfLines, sizeOfFile);
     }
 
     @CloudKeeperSerialization(ByteSequenceMarshaler.class)

--- a/cloudkeeper-samples/cloudkeeper-sample-single-vm/src/test/java/com/svbio/cloudkeeper/samples/SingleVMTest.java
+++ b/cloudkeeper-samples/cloudkeeper-sample-single-vm/src/test/java/com/svbio/cloudkeeper/samples/SingleVMTest.java
@@ -6,8 +6,6 @@ import com.svbio.cloudkeeper.dsl.SimpleModulePlugin;
 import com.svbio.cloudkeeper.model.api.CloudKeeperEnvironment;
 import com.svbio.cloudkeeper.model.api.WorkflowExecution;
 import com.svbio.cloudkeeper.model.util.ByteSequences;
-import com.svbio.cloudkeeper.simple.AwaitException;
-import com.svbio.cloudkeeper.simple.WorkflowExecutions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -53,8 +51,8 @@ public final class SingleVMTest {
         WorkflowExecution execution
             = divideModule.newPreconfiguredWorkflowExecutionBuilder(cloudKeeperEnvironment).start();
         try {
-            WorkflowExecutions.awaitFinish(execution, 1, TimeUnit.SECONDS);
-        } catch (AwaitException|TimeoutException|InterruptedException exception) {
+            execution.toCompletableFuture().get(1, TimeUnit.SECONDS);
+        } catch (ExecutionException|TimeoutException|InterruptedException exception) {
             LOG.debug("An expected exception occurred!", exception);
         }
     }

--- a/src/main/config/suppressions.xml
+++ b/src/main/config/suppressions.xml
@@ -4,7 +4,7 @@
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
-<!-- Suppress application of checkstyle rules to auto-generared files located in target/ -->
+<!-- Suppress application of checkstyle rules to auto-generated files located in target/ -->
 <suppressions>
   <suppress files="[/\\]target[/\\]" checks=".*"/>
 </suppressions>


### PR DESCRIPTION
For each method in interface WorkflowExecution that accepts an argument
of type OnActionComplete, replaced by a corresponding method returning
CompletableFuture.
