### PR TITLE
[#16] Added missing test dependency slf4j-simple

### DIFF
--- a/cloudkeeper-executors/cloudkeeper-forking-executor/pom.xml
+++ b/cloudkeeper-executors/cloudkeeper-forking-executor/pom.xml
@@ -25,6 +25,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <usedDependencies>
+                        <usedDependency>org.slf4j:slf4j-simple</usedDependency>
+                    </usedDependencies>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -74,6 +83,12 @@
             <groupId>com.svbio.cloudkeeper.executors</groupId>
             <artifactId>cloudkeeper-executors-testkit</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Running tests in cloudkeeper-executors/cloudkeeper-forking-executor
triggers error messages that class org.slf4j.impl.StaticLoggerBinder
cannot be loaded. This is due to the fact that some of the packages on
which running of tests depend on themselves depend non-transitively
on org.slf4j:slf4j-simple package. This pacth set fixes this issue.
